### PR TITLE
Additional Exception Handling in size.py

### DIFF
--- a/cog/tasks/size.py
+++ b/cog/tasks/size.py
@@ -43,8 +43,9 @@ class SizeCheck(cog.task.Task):
             return {'success': False, 'reason': 'missing revision id'}
         if git_url is None:
             return {'success': False, 'reason': 'missing git url'}
-        if (base_repo_url and base_repo_ref is None or
-                base_repo_ref and base_repo_url is None):
+        if ((base_repo_url and base_repo_ref is None) or
+            (base_repo_ref and base_repo_url is None) or
+            (base_repo_ref is None and base_repo_url is None)): 
             return {'success': False,
                     'reason': 'incomplete base specification for merge'}
 


### PR DESCRIPTION
Added handling for the exceptional case where both the 'base_repo_ref' and 'base_repo_url' string variables carry a 'None' value.